### PR TITLE
Fix bug: use site config email as the receiver in contact us form

### DIFF
--- a/app/Jobs/Email/Send/ContactFormSubmitted.php
+++ b/app/Jobs/Email/Send/ContactFormSubmitted.php
@@ -39,7 +39,7 @@ class ContactFormSubmitted implements ShouldQueue
     public function handle()
     {
         if($this->lead && $this->siteConfig){
-            Mail::to($this->lead->email)
+            Mail::to($this->siteConfig->email)
                 ->send(new LeadReceivedToAdmin($this->lead, $this->siteConfig));
         }
     }


### PR DESCRIPTION
修复了一个Bug